### PR TITLE
Upgrade Jersey from v2 to v3

### DIFF
--- a/athena-core/pom.xml
+++ b/athena-core/pom.xml
@@ -25,6 +25,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.qubitpi.athena</groupId>
             <artifactId>athena-system-config</artifactId>
         </dependency>
@@ -75,14 +87,21 @@
         </dependency>
 
         <!-- Injection -->
+<!--        <dependency>-->
+<!--            <groupId>org.glassfish.hk2</groupId>-->
+<!--            <artifactId>hk2-api</artifactId>-->
+<!--        </dependency>-->
         <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-api</artifactId>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>javax.inject</groupId>-->
+<!--            <artifactId>javax.inject</artifactId>-->
+<!--        </dependency>-->
+
+
+
 
         <!-- JAXB Binding (JDK 11+) -->
         <dependency>

--- a/athena-core/pom.xml
+++ b/athena-core/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
@@ -83,10 +87,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-locator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <!-- JAXB Binding (JDK 11+) -->

--- a/athena-core/pom.xml
+++ b/athena-core/pom.xml
@@ -47,6 +47,10 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
 
         <!-- Jersey -->
         <dependency>
@@ -56,10 +60,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/athena-core/pom.xml
+++ b/athena-core/pom.xml
@@ -24,18 +24,7 @@
     </licenses>
 
     <dependencies>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-locator</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-
-
+        <!-- Local module dependencies -->
         <dependency>
             <groupId>com.qubitpi.athena</groupId>
             <artifactId>athena-system-config</artifactId>
@@ -55,8 +44,8 @@
 
         <!-- Servlet API -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <!-- Jersey -->
@@ -87,21 +76,18 @@
         </dependency>
 
         <!-- Injection -->
-<!--        <dependency>-->
-<!--            <groupId>org.glassfish.hk2</groupId>-->
-<!--            <artifactId>hk2-api</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>javax.inject</groupId>-->
-<!--            <artifactId>javax.inject</artifactId>-->
-<!--        </dependency>-->
-
-
-
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
 
         <!-- JAXB Binding (JDK 11+) -->
         <dependency>

--- a/athena-core/src/main/java/com/qubitpi/athena/application/ResourceConfig.java
+++ b/athena-core/src/main/java/com/qubitpi/athena/application/ResourceConfig.java
@@ -25,9 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.ApplicationPath;
 
-import javax.inject.Inject;
-import javax.ws.rs.ApplicationPath;
+import jakarta.inject.Inject;
 
 /**
  * The resource configuration for the Athena web applications.

--- a/athena-core/src/main/java/com/qubitpi/athena/web/endpoints/FileServlet.java
+++ b/athena-core/src/main/java/com/qubitpi/athena/web/endpoints/FileServlet.java
@@ -23,7 +23,17 @@ import com.qubitpi.athena.metastore.MetaStore;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
@@ -31,17 +41,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 /**
  * Endpoint for POSTing files.

--- a/athena-core/src/main/java/com/qubitpi/athena/web/endpoints/MetaServlet.java
+++ b/athena-core/src/main/java/com/qubitpi/athena/web/endpoints/MetaServlet.java
@@ -24,22 +24,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
 import java.util.List;
 import java.util.Objects;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * Endpoint for POSTing and GETing file metadata.

--- a/athena-core/src/test/groovy/com/qubitpi/athena/application/ResourceConfigSpec.groovy
+++ b/athena-core/src/test/groovy/com/qubitpi/athena/application/ResourceConfigSpec.groovy
@@ -63,7 +63,7 @@ class ResourceConfigSpec extends Specification {
         ResourceConfig config = resourceConfigClass.getDeclaredConstructor().newInstance() as ResourceConfig
 
         then:
-        // config.classes.containsAll(filters) TODO - this issue is big enough that deserves a separate PR
+        config.classes.containsAll(filters)
         config.getInstances().contains(binder)
 
         1 * clicker.accept(MockingBinderFactory.INIT)

--- a/athena-core/src/test/groovy/com/qubitpi/athena/web/endpoints/FileServletSpec.groovy
+++ b/athena-core/src/test/groovy/com/qubitpi/athena/web/endpoints/FileServletSpec.groovy
@@ -26,12 +26,11 @@ import org.glassfish.jersey.media.multipart.MultiPart
 import org.glassfish.jersey.media.multipart.MultiPartFeature
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart
 
+import jakarta.ws.rs.client.Entity
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
 import java.util.function.BiFunction
-
-import javax.ws.rs.client.Entity
 
 class FileServletSpec extends Specification {
 

--- a/athena-core/src/test/groovy/com/qubitpi/athena/web/endpoints/MetaServletSpec.groovy
+++ b/athena-core/src/test/groovy/com/qubitpi/athena/web/endpoints/MetaServletSpec.groovy
@@ -23,12 +23,11 @@ import com.qubitpi.athena.metastore.MetaStore
 import com.qubitpi.athena.web.graphql.JsonDocumentParser
 
 import groovy.json.JsonSlurper
+import jakarta.ws.rs.client.Entity
+import jakarta.ws.rs.core.MediaType
 import spock.lang.Specification
 
 import java.util.function.BiFunction
-
-import javax.ws.rs.client.Entity
-import javax.ws.rs.core.MediaType
 
 class MetaServletSpec extends Specification {
 

--- a/athena-core/src/test/java/com/qubitpi/athena/application/JerseyTestBinder.java
+++ b/athena-core/src/test/java/com/qubitpi/athena/application/JerseyTestBinder.java
@@ -23,15 +23,14 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Application;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Application;
 
 /**
  * Configures JerseyTest and also sets up DI.

--- a/athena-core/src/test/java/com/qubitpi/athena/filestore/TestFileStore.java
+++ b/athena-core/src/test/java/com/qubitpi/athena/filestore/TestFileStore.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 /**
  * A {@link FileStore} test stub that facilitates {@link com.qubitpi.athena.web.endpoints.FileServletSpec} mocking

--- a/athena-core/src/test/java/com/qubitpi/athena/metastore/TestMetaStore.java
+++ b/athena-core/src/test/java/com/qubitpi/athena/metastore/TestMetaStore.java
@@ -39,8 +39,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 /**
  * A {@link MetaStore} test stub that facilitates {@link com.qubitpi.athena.web.endpoints.MetaServletSpec} mocking

--- a/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/BooksBinderFactory.java
+++ b/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/BooksBinderFactory.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 import graphql.schema.DataFetcher;
 import jakarta.validation.constraints.NotNull;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import javax.sql.DataSource;
 
 /**

--- a/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/SQLMutationDataFetcher.java
+++ b/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/SQLMutationDataFetcher.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.sql.DataSource;
 
 /**

--- a/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/SQLQueryDataFetcher.java
+++ b/athena-examples/athena-example-books/src/main/java/com/qubitpi/athena/example/books/application/SQLQueryDataFetcher.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.sql.DataSource;
 
 /**

--- a/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/application/BooksBinderFactorySpec.groovy
+++ b/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/application/BooksBinderFactorySpec.groovy
@@ -21,7 +21,7 @@ import com.qubitpi.athena.config.SystemConfigFactory
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import javax.inject.Provider
+import jakarta.inject.Provider
 import javax.sql.DataSource
 
 class BooksBinderFactorySpec extends Specification {

--- a/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/web/endpoints/FileServletSpec.groovy
+++ b/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/web/endpoints/FileServletSpec.groovy
@@ -25,10 +25,9 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart
 
 import groovy.json.JsonSlurper
+import jakarta.ws.rs.client.Entity
 
 import java.nio.charset.StandardCharsets
-
-import javax.ws.rs.client.Entity
 
 class FileServletSpec extends AbstractServletSpec {
 

--- a/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/web/endpoints/MetaServletSpec.groovy
+++ b/athena-examples/athena-example-books/src/test/groovy/com/qubitpi/athena/example/books/web/endpoints/MetaServletSpec.groovy
@@ -19,9 +19,8 @@ import com.qubitpi.athena.example.books.application.BookJerseyTestBinder
 import com.qubitpi.athena.web.endpoints.MetaServlet
 
 import groovy.json.JsonSlurper
-
-import javax.ws.rs.client.Entity
-import javax.ws.rs.core.MediaType
+import jakarta.ws.rs.client.Entity
+import jakarta.ws.rs.core.MediaType
 
 class MetaServletSpec extends AbstractServletSpec {
 

--- a/athena-filestore/athena-filestore-swift/pom.xml
+++ b/athena-filestore/athena-filestore-swift/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>joss</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
         </dependency>

--- a/athena-filestore/athena-filestore-swift/src/main/java/com/qubitpi/athena/filestore/swift/SwiftFileStore.java
+++ b/athena-filestore/athena-filestore-swift/src/main/java/com/qubitpi/athena/filestore/swift/SwiftFileStore.java
@@ -28,8 +28,8 @@ import net.jcip.annotations.NotThreadSafe;
 import java.io.InputStream;
 import java.util.Objects;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * An OpenStack Swift implementation of {@link FileStore}.

--- a/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/GraphQLFactory.java
+++ b/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/GraphQLFactory.java
@@ -36,7 +36,7 @@ import net.jcip.annotations.ThreadSafe;
 import java.util.Objects;
 import java.util.Scanner;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 /**
  * {@link GraphQLFactory} initializes {@link GraphQL native GraphQL API}.

--- a/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/GraphQLMetaStore.java
+++ b/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/GraphQLMetaStore.java
@@ -35,9 +35,9 @@ import net.jcip.annotations.NotThreadSafe;
 import java.util.List;
 import java.util.Objects;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 /**
  * The default implementation of {@link MetaStore}.

--- a/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/query/TemplateBasedGraphQLQueryProvider.java
+++ b/athena-metastore/athena-metastore-graphql/src/main/java/com/qubitpi/athena/metastore/graphql/query/TemplateBasedGraphQLQueryProvider.java
@@ -30,7 +30,7 @@ import net.jcip.annotations.ThreadSafe;
 import java.util.List;
 import java.util.Objects;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 /**
  * The default implementation of {@link GraphQLQueryProvider}.

--- a/athena-system-config/pom.xml
+++ b/athena-system-config/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
-        <!--        <dependency>-->
-<!--            <groupId>javax.inject</groupId>-->
-<!--            <artifactId>javax.inject</artifactId>-->
-<!--        </dependency>-->
-
         <!-- Apache Commons Libraries -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/athena-system-config/pom.xml
+++ b/athena-system-config/pom.xml
@@ -26,9 +26,14 @@
     <dependencies>
         <!-- Injection -->
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
+
+        <!--        <dependency>-->
+<!--            <groupId>javax.inject</groupId>-->
+<!--            <artifactId>javax.inject</artifactId>-->
+<!--        </dependency>-->
 
         <!-- Apache Commons Libraries -->
         <dependency>

--- a/athena-system-config/src/main/java/com/qubitpi/athena/config/LayeredFileSystemConfig.java
+++ b/athena-system-config/src/main/java/com/qubitpi/athena/config/LayeredFileSystemConfig.java
@@ -35,7 +35,7 @@ import java.util.Properties;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 /**
  * A class to hold and fetch configuration values from the environment and runtime.

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
                 <version>${version.jersey}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-multipart</artifactId>
                 <version>${version.jersey}</version>
@@ -247,11 +252,6 @@
             <dependency>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-locator</artifactId>
-                <version>3.0.0</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>3.0.0</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,11 @@
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${version.servlet}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.0.0</version>
+            </dependency>
 
             <!-- Jersey -->
             <dependency>
@@ -214,11 +219,6 @@
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
                 <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.apache.commons>2.7</version.apache.commons>
         <version.commons.dbcp2>2.0.1</version.commons.dbcp2>
         <version.mysql.connector.java>5.1.38</version.mysql.connector.java>
-        <version.servlet>3.1.0</version.servlet>
+        <version.servlet>6.0.0</version.servlet>
         <version.jersey>3.0.8</version.jersey>
         <version.derby>10.11.1.1</version.derby>
         <version.flyway.core>5.0.7</version.flyway.core>
@@ -199,8 +199,8 @@
 
             <!-- Servlet API -->
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
                 <version>${version.servlet}</version>
             </dependency>
 
@@ -239,14 +239,19 @@
             </dependency>
 
             <!-- Injection -->
-<!--            <dependency>-->
-<!--                <groupId>org.glassfish.hk2</groupId>-->
-<!--                <artifactId>hk2-api</artifactId>-->
-<!--                <version>2.5.0-b32</version>-->
-<!--            </dependency>-->
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>
                 <artifactId>jersey-hk2</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-locator</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>3.0.0</version>
             </dependency>
             <dependency>
@@ -254,11 +259,6 @@
                 <artifactId>jakarta.inject-api</artifactId>
                 <version>2.0.1</version>
             </dependency>
-<!--            <dependency>-->
-<!--                <groupId>javax.inject</groupId>-->
-<!--                <artifactId>javax.inject</artifactId>-->
-<!--                <version>1</version>-->
-<!--            </dependency>-->
 
             <!-- JAXB Binding (JDK 11+) -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
         <version.slf4j>1.7.25</version.slf4j>
         <version.logback>1.2.3</version.logback>
         <version.graphql.java>14.0</version.graphql.java>
-        <version.joss>0.10.2</version.joss>
+        <version.joss>0.10.4</version.joss>
         <version.jackson>2.13.3</version.jackson>
         <version.apache.commons>2.7</version.apache.commons>
         <version.commons.dbcp2>2.0.1</version.commons.dbcp2>
         <version.mysql.connector.java>5.1.38</version.mysql.connector.java>
         <version.servlet>3.1.0</version.servlet>
-        <version.jersey>2.25.1</version.jersey>
+        <version.jersey>3.0.8</version.jersey>
         <version.derby>10.11.1.1</version.derby>
         <version.flyway.core>5.0.7</version.flyway.core>
 
@@ -225,13 +225,13 @@
                 <artifactId>jersey-media-json-jackson</artifactId>
                 <version>${version.jersey}</version>
             </dependency>
-            <dependency><!-- Client for running local "integration-style" tests -->
+            <dependency> <!-- Client for running local "integration-style" tests -->
                 <groupId>org.glassfish.jersey.test-framework</groupId>
                 <artifactId>jersey-test-framework-core</artifactId>
                 <version>${version.jersey}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency><!-- Container for running local "integration-style" tests -->
+            <dependency> <!-- Container for running local "integration-style" tests -->
                 <groupId>org.glassfish.jersey.test-framework.providers</groupId>
                 <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
                 <version>${version.jersey}</version>
@@ -239,27 +239,37 @@
             </dependency>
 
             <!-- Injection -->
+<!--            <dependency>-->
+<!--                <groupId>org.glassfish.hk2</groupId>-->
+<!--                <artifactId>hk2-api</artifactId>-->
+<!--                <version>2.5.0-b32</version>-->
+<!--            </dependency>-->
             <dependency>
-                <groupId>org.glassfish.hk2</groupId>
-                <artifactId>hk2-api</artifactId>
-                <version>2.5.0-b32</version>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>2.0.1</version>
             </dependency>
+<!--            <dependency>-->
+<!--                <groupId>javax.inject</groupId>-->
+<!--                <artifactId>javax.inject</artifactId>-->
+<!--                <version>1</version>-->
+<!--            </dependency>-->
 
             <!-- JAXB Binding (JDK 11+) -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.2</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.2</version>
+                <version>3.0.0</version>
             </dependency>
 
             <!-- Testing -->


### PR DESCRIPTION
<img align="right" width="30%" src="https://github.com/QubitPi/QubitPi/raw/master/img/athena/Elysia.png">

Changelog
---------

- Upgrade Jersey version from 2.25.1 to **3.0.8**
- Replace `javax`-based dependency injection with the new `jakarta`-based

  * For example, `import javax.inject.Inject;` is replaced by `import jakarta.inject.Inject;`
  * All `javax`-prefixed dependency are replaced by its `jakarta` equivalence in POM, except for `javax.sql` and `javax.activation`
  * Bumps hk2 `v2` to `v3` accordingly

- Bump JAXB-Binding version from v2 to v3
- Bump OpenStack Swift client library (joss) version from 0.10.2 to 0.10.4 


Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation


Lessons Learned
-----------------

- When we are considering integrating a new library/component/system, it must keep up to speed with our environment. For example, when JDK goes from 8 to 11, that library/component/system must also support working with 11 quickly so that importing that library/component/system won't have versioning conflicts with our internals. For this reason, joss was not a super nice thing to have because we still need to import old `javax.activation` dependency and make it live alongside with new `jakarta.activation`:

  ```xml
  <dependency>
      <groupId>javax.activation</groupId>
      <artifactId>activation</artifactId>
      <version>1.1.1</version>
  </dependency>
  <dependency>
      <groupId>com.sun.activation</groupId>
      <artifactId>jakarta.activation</artifactId>
  </dependency>
  ```
- Jersey is really an ecosystem consisting of

  1. Jersey
  2. HK2
  3. Jakarta DI Specification

  **Changing the version of any one of these above requires careful analysis and testing against the other two**


Reference
----------

- [Jersey Migration Guide](https://eclipse-ee4j.github.io/jersey.github.io/documentation/3.0.0/migration.html#mig-2.26)