### PR TITLE
Compiler plugin should be a default dependency for all modules

### DIFF
--- a/athena-examples/athena-example-acceptance-tests/pom.xml
+++ b/athena-examples/athena-example-acceptance-tests/pom.xml
@@ -111,10 +111,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -577,6 +577,11 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Checklist

- [ ] Test
- [ ] Self-review
- [ ] Documentation
